### PR TITLE
Fix firewall init script on Debian 8

### DIFF
--- a/kura/distrib/src/main/resources/pcengines-apu/firewall.init
+++ b/kura/distrib/src/main/resources/pcengines-apu/firewall.init
@@ -1,4 +1,14 @@
-#!/bin/bash
+#! /bin/bash
+### BEGIN INIT INFO
+# Provides:          firewall
+# Required-Start:    $networking
+# Required-Stop:     $all
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Save and restore firewall for Kura
+# Description:
+### END INIT INFO
+
 # iptables-restore script
 iptables_config_file=/etc/sysconfig/iptables
 ipforward_file=/proc/sys/net/ipv4/ip_forward


### PR DESCRIPTION
Right now newish Debian is missing the init.d header with all dependancies of the firewall init script. If it is missing the init script is marked as invalid and many dpkg operations fail. This is in my PC Engines apu setup folder but applies to all Debian 8 / Raspbian based systems (Raspberry, Beaglebone, ...). I can provide the pull request also for these packages.
